### PR TITLE
[fix]: hactoberfest button text color on mobile view

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -838,7 +838,8 @@ section {
   padding: 0;
   margin: 0;
 }
-.hacktoberfest-btn {
+.hacktoberfest-btn,
+.navbar-mobile .hacktoberfest-btn {
   background-color: #0c2e8a;
   color: #fff;
 }


### PR DESCRIPTION
## Related Issue
- #61 

## Proposed Changes
- Changed the button text to white in mobile mode.

## Additional Info
- Any additional information or context

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] ✅ My code follows the code style of this project.
- [ ] 📝 My change requires a change to the documentation.
- [ ] 🎀 I have updated the documentation accordingly.
- [x] 🌟 ed the repo

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!--- Provide a general summary of your changes in the Title above -->
Changed the text color of hacktoberfest button color to white in the mobile view.

<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/agamjotsingh18/codesetgo-website/issues/61

<!--- Describe your changes in detail -->
Changed the text color of hacktoberfest button color (which was blue earlier and hence was unreadable) to white in the mobile view.


<!--- Why is this change required? What problem does it solve? -->
Earlier, the text was not readable on the mobile view but now it is.

<!--- see how your change affects other areas of the code, etc. -->
It doesn't affect any other areas of code.



## Output Screenshots
| Screenshot #1      | Screenshot #2  |
| ----------- | ----------- |
| Before | After    |
| 
![image](https://user-images.githubusercontent.com/52596800/194153697-e23a4062-8a26-42e8-b485-4f2e52655875.png)
  | 
![image](https://user-images.githubusercontent.com/52596800/194153633-4b3d5381-0c36-443e-b302-f7107f159b21.png)

